### PR TITLE
This solve the problem whit the new version of ggplot.

### DIFF
--- a/Statistical_Inference/Hypothesis_Testing/conf_5pct.R
+++ b/Statistical_Inference/Hypothesis_Testing/conf_5pct.R
@@ -1,7 +1,7 @@
 x <- seq(-8,8, length = 2000)
 dat <- data.frame(x=x, y=dnorm(x,sd=2))
 g <- ggplot(dat, aes(x = x, y = y)) + geom_line(size = 1.5)+scale_y_continuous(limits=c(0,max(dat$y)))
-suppressWarnings(g <- g+ layer("area",mapping = aes(x=ifelse(x>qnorm(.95,sd=2),x,NA)),
-            geom_params=list(fill="red",alpha=.5)) )
+suppressWarnings(g <- g+ layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(x>qnorm(.95,sd=2),x,NA)),
+            params=list(fill="red",alpha=.5, na.rm=TRUE)) )
 suppressWarnings(print(g))
 


### PR DESCRIPTION
Solve the following problem in ggplot2 version 2.0.0 or later:

| which the probability that X>C is 5%.

Error in layer("area", mapping = aes(x = ifelse(x > qnorm(0.95, sd = 2), :

unused argument (geom_params = list(fill = "red", alpha = 0.5))

| Leaving swirl now. Type swirl() to resume.
